### PR TITLE
Change write security actions to add missing actions for future UCD v…

### DIFF
--- a/UCADF-Package-Test/Test/Actions/environmentActionTests.yml
+++ b/UCADF-Package-Test/Test/Actions/environmentActionTests.yml
@@ -24,6 +24,41 @@ actions:
         description: "Test environment"
         failIfExists: false
 
+  # Create an environment of each color.
+  - action: UcAdfItemsLoop
+    items:
+      - RED
+      - ORANGE
+      - YELLOW
+      - GREEN
+      - TEAL
+      - BLUE
+      - DARKRED
+      - DARKORANGE
+      - DARKYELLOW
+      - DARKGREEN
+      - DARKTEAL
+      - DARKBLUE
+      - BLUE2
+      - LIGHTPURPLE
+      - LIGHTPINK
+      - TAUPE
+      - GRAY
+      - GRAY2
+      - DARKBLUE2
+      - PURPLE
+      - PINK
+      - DARKTAUPE
+      - DARKGRAY
+      - DARKGRAY2
+    actions:
+      - action: UcdCreateEnvironment
+        application: "${u:coreTestApp1}"
+        name: "${u:coreTestEnv1} ${u:item}"
+        color: "${u:item}"
+        description: "This is ${u:item}"
+        failIfExists: false
+
   # Add team security to a specified environment.
   - action: UcdAddEnvironmentToTeams
     application: "${u:coreTestApp1}"

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/authenticationRealm/UcdCreateLdapAuthenticationRealm.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/authenticationRealm/UcdCreateLdapAuthenticationRealm.groovy
@@ -133,8 +133,8 @@ class UcdCreateLdapAuthenticationRealm extends UcAdfAction {
 			Boolean alreadyExists = false
 			if ((response.getStatus() == 400 || response.getStatus() == 403) && errMsg ==~ /.*already exists.*/) {
 				alreadyExists = true
-			} else if (response.getStatus() == 500 && errMsg ==~ /.*after response has been committed.*/) {
-				// UCD 7.0.4 is returning 500 Cannot forward after response has been committed if it already exists.
+			} else if (response.getStatus() == 500) {
+				// UCD 7.0.4 and/or 7.0.5 are returning 500 if it already exists.
 				alreadyExists = true
 			}
 			

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/authorizationRealm/UcdCreateLdapAuthorizationRealm.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/authorizationRealm/UcdCreateLdapAuthorizationRealm.groovy
@@ -87,8 +87,8 @@ class UcdCreateLdapAuthorizationRealm extends UcAdfAction {
 			Boolean alreadyExists = false
 			if ((response.getStatus() == 400 || response.getStatus() == 403) && errMsg ==~ /.*already exists.*/) {
 				alreadyExists = true
-			} else if (response.getStatus() == 500 && errMsg ==~ /.*after response has been committed.*/) {
-				// UCD 7.0.4 is returning 500 Cannot forward after response has been committed if it already exists.
+			} else if (response.getStatus() == 500) {
+				// UCD 7.0.4 and/or 7.0.5 are returning 500 if it already exists.
 				alreadyExists = true
 			}
 			

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/componentConfigTemplate/UcdCreateComponentConfigTemplate.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/componentConfigTemplate/UcdCreateComponentConfigTemplate.groovy
@@ -78,8 +78,8 @@ class UcdCreateComponentConfigTemplate extends UcAdfAction {
 			Boolean alreadyExists = false
 			if (response.getStatus() == 405) {
 				alreadyExists = true
-			} else if (response.getStatus() == 500 && errMsg ==~ /.*after response has been committed.*/) {
-				// UCD 7.0.4 is returning 500 Cannot forward after response has been committed if it already exists.
+			} else if (response.getStatus() == 500) {
+				// UCD 7.0.4 and/or 7.0.5 are returning 500 if it already exists.
 				alreadyExists = true
 			}
 			

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/role/UcdCreateRole.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/role/UcdCreateRole.groovy
@@ -59,8 +59,8 @@ class UcdCreateRole extends UcAdfAction {
 			Boolean alreadyExists = false
 			if ((response.getStatus() == 400 || response.getStatus() == 403) && errMsg ==~ /.*already exists.*/) {
 				alreadyExists = true
-			} else if (response.getStatus() == 500 && errMsg ==~ /.*after response has been committed.*/) {
-				// UCD 7.0.4 is returning 500 Cannot forward after response has been committed if it already exists.
+			} else if (response.getStatus() == 500) {
+				// UCD 7.0.4 and/or 7.0.5 are returning 500 if it already exists.
 				alreadyExists = true
 			}
 			

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/security/UcdCreateSecuritySubtype.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/security/UcdCreateSecuritySubtype.groovy
@@ -68,8 +68,8 @@ class UcdCreateSecuritySubtype extends UcAdfAction {
 			Boolean alreadyExists = false
 			if ((response.getStatus() == 400 || response.getStatus() == 403) && errMsg ==~ /.*already exists.*/) {
 				alreadyExists = true
-			} else if (response.getStatus() == 500 && errMsg ==~ /.*after response has been committed.*/) {
-				// UCD 7.0.4 is returning 500 Cannot forward after response has been committed if it already exists.
+			} else if (response.getStatus() == 500) {
+				// UCD 7.0.4 and/or 7.0.5 are returning 500 if it already exists.
 				alreadyExists = true
 			}
 			

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/user/UcdCreateUser.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/user/UcdCreateUser.groovy
@@ -73,8 +73,8 @@ class UcdCreateUser extends UcAdfAction {
 			Boolean alreadyExists = false
 			if ((response.getStatus() == 400 || response.getStatus() == 403) && errMsg ==~ /.*already exists.*/) {
 				alreadyExists = true
-			} else if (response.getStatus() == 500 && errMsg ==~ /.*after response has been committed.*/) {
-				// UCD 7.0.4 is returning 500 Cannot forward after response has been committed if it already exists.
+			} else if (response.getStatus() == 500) {
+				// UCD 7.0.4 and/or 7.0.5 are returning 500 if it already exists.
 				alreadyExists = true
 			}
 			

--- a/src/main/groovy/org/urbancode/ucadf/core/actionsrunner/UcAdfAction.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/actionsrunner/UcAdfAction.groovy
@@ -2,11 +2,11 @@ package org.urbancode.ucadf.core.actionsrunner
 
 import org.urbancode.ucadf.core.model.ucadf.UcAdfSecureString
 import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
+import org.urbancode.ucadf.core.model.ucadf.objectmapper.UcAdfObjectMapper
 import org.urbancode.ucadf.core.model.ucd.general.UcdObject
 import org.urbancode.ucadf.core.model.ucd.system.UcdSession
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.databind.ObjectMapper
 
 import groovy.util.logging.Slf4j
 
@@ -192,12 +192,7 @@ abstract class UcAdfAction extends UcdObject {
 					}
 				}
 				
-				String outputStr
-				if (propValue instanceof UcAdfSecureString) {
-					outputStr = "***"
-				} else {
-					outputStr = new ObjectMapper().writer().writeValueAsString(propValue)
-				}
+				String outputStr = new UcAdfObjectMapper().writer().writeValueAsString(propValue)
 				
 				println "-> $propName=[$outputStr]"
 			}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/UcAdfObject.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/UcAdfObject.groovy
@@ -6,7 +6,7 @@ package org.urbancode.ucadf.core.model.ucadf
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import org.urbancode.ucadf.core.model.ucadf.objectmapper.UcAdfObjectMapper
 
 abstract class UcAdfObject implements Serializable {
 	/**
@@ -15,7 +15,7 @@ abstract class UcAdfObject implements Serializable {
 	 * @return The pretty print formatted string.
 	 */
 	public static String toJsonPrettyString(final Object object) {
-		return new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(object)
+		return new UcAdfObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(object)
 	}
 	
 	/**
@@ -32,7 +32,7 @@ abstract class UcAdfObject implements Serializable {
 	 * @return The formatted string.
 	 */
 	public static String toJsonString(final Object object) {
-		return new ObjectMapper().writer().writeValueAsString(object)
+		return new UcAdfObjectMapper().writer().writeValueAsString(object)
 	}
 
 	/**

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/UcAdfSecureString.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/UcAdfSecureString.groovy
@@ -3,13 +3,21 @@
  */
 package org.urbancode.ucadf.core.model.ucadf
 
+import org.urbancode.ucadf.core.model.ucadf.objectmapper.UcAdfMasked
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class UcAdfSecureString extends UcAdfObject {
 	// This will have the String class methods.
-	@Delegate final String secureString
-	
+	@UcAdfMasked
+	@Delegate 
+	final String secureString
+
+	@UcAdfMasked
+	@Delegate
+	final String bytes
+
 	// Constructors.	
 	UcAdfSecureString() {
 		this("")

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/loop/UcAdfCounterLoopControl.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/loop/UcAdfCounterLoopControl.groovy
@@ -3,12 +3,12 @@
  */
 package org.urbancode.ucadf.core.model.ucadf.loop
 
-import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+import org.urbancode.ucadf.core.model.ucadf.UcAdfObject
 
 import groovy.util.logging.Slf4j
 
 @Slf4j
-class UcAdfCounterLoopControl extends UcdObject {
+class UcAdfCounterLoopControl extends UcAdfObject {
 	/** The default loop control property name. */
 	public static LOOPCONTROLPROPERTYNAME = "counterLoopControl"
 	

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/loop/UcAdfPageLoopControl.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/loop/UcAdfPageLoopControl.groovy
@@ -6,12 +6,12 @@ package org.urbancode.ucadf.core.model.ucadf.loop
 import javax.ws.rs.core.MultivaluedMap
 import javax.ws.rs.core.Response
 
-import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+import org.urbancode.ucadf.core.model.ucadf.UcAdfObject
 
 import groovy.util.logging.Slf4j
 
 @Slf4j
-class UcAdfPageLoopControl extends UcdObject {
+class UcAdfPageLoopControl extends UcAdfObject {
 	/** The default loop control property name. */
 	public static LOOPCONTROLPROPERTYNAME = "pageLoopControl"
 	

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/loop/UcAdfWaitLoopControl.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/loop/UcAdfWaitLoopControl.groovy
@@ -3,12 +3,12 @@
  */
 package org.urbancode.ucadf.core.model.ucadf.loop
 
-import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+import org.urbancode.ucadf.core.model.ucadf.UcAdfObject
 
 import groovy.util.logging.Slf4j
 
 @Slf4j
-class UcAdfWaitLoopControl extends UcdObject {
+class UcAdfWaitLoopControl extends UcAdfObject {
 	/** The default loop control property name. */
 	public static LOOPCONTROLPROPERTYNAME = "waitLoopControl"
 	

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/objectmapper/UcAdfAnnotationIntrospector.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/objectmapper/UcAdfAnnotationIntrospector.groovy
@@ -1,0 +1,70 @@
+package org.urbancode.ucadf.core.model.ucadf.objectmapper
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.introspect.Annotated
+import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+
+// Map a serializer/deserializer based on a custom annotation.
+public class UcAdfAnnotationIntrospector extends NopAnnotationIntrospector {
+    private static final long serialVersionUID = 1L;
+
+	// If the object has a mask annotation then use the mask serializer.
+    @Override
+    public Object findSerializer(Annotated am) {
+		Object serializer
+        if (am.getAnnotation(UcAdfMasked.class)) {
+            serializer = UcAdfMaskedSerializer.class
+        }
+
+        return serializer
+    }
+
+	// Custom mask serializer.	
+	static public class UcAdfMaskedSerializer extends StdSerializer {
+		private static final long serialVersionUID = 1L
+	
+		public UcAdfMaskedSerializer() {
+			super(String.class)
+		}
+	
+		@Override
+		public void serialize(
+			final Object object,
+			final JsonGenerator jsonGenerator,
+			final SerializerProvider provider) throws IOException {
+			
+			jsonGenerator.writeString("***")
+		}
+	}
+
+//	// If the object has a mask annotation then used the mask deserializer.
+//    @Override
+//    public Object findDeserializer(Annotated am) {
+//		Object deserializer
+//		
+//        if (am.getAnnotation(UcAdfMaskedString.class)) {
+//            deserializer = UcAdfMaskedDeserializer.class
+//        }
+//
+//        return deserializer
+//    }
+//
+//	// Custom mask deserializer.	
+//	static class UcAdfMaskedDeserializer extends StdDeserializer<String> {
+//	    private static final long serialVersionUID = 1L
+//	
+//	    public UcAdfMaskedDeserializer() {
+//	        super(String.class)
+//	    }
+//	
+//	    @Override
+//	    public String deserialize(
+//			final JsonParser jsonParser, 
+//			final DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+//			
+//			return jsonParser.getValueAsString()
+//	    }
+//	}
+}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/objectmapper/UcAdfMasked.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/objectmapper/UcAdfMasked.groovy
@@ -1,0 +1,12 @@
+package org.urbancode.ucadf.core.model.ucadf.objectmapper
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface UcAdfMasked {
+	String value() default "***"
+}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/objectmapper/UcAdfObjectMapper.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucadf/objectmapper/UcAdfObjectMapper.groovy
@@ -1,0 +1,19 @@
+package org.urbancode.ucadf.core.model.ucadf.objectmapper
+
+import com.fasterxml.jackson.databind.AnnotationIntrospector
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair
+
+class UcAdfObjectMapper extends ObjectMapper {
+	UcAdfObjectMapper() {
+		super()
+		
+        AnnotationIntrospector serializerIntrospector = this.getSerializationConfig().getAnnotationIntrospector()
+        AnnotationIntrospector deserializerIntrospector = this.getDeserializationConfig().getAnnotationIntrospector()
+
+        AnnotationIntrospector customSerializerIntrospector = AnnotationIntrospectorPair.pair(serializerIntrospector, new UcAdfAnnotationIntrospector())
+        AnnotationIntrospector customDeserializerIntrospector = AnnotationIntrospectorPair.pair(deserializerIntrospector, new UcAdfAnnotationIntrospector())
+		
+        this.setAnnotationIntrospectors(customSerializerIntrospector, deserializerIntrospector)
+	}
+}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/agentRelay/UcdAgentRelay.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/agentRelay/UcdAgentRelay.groovy
@@ -48,7 +48,16 @@ class UcdAgentRelay extends UcdSecurityTypeObject {
 	
 	/** The extended security. */
 	UcdExtendedSecurity extendedSecurity
+
+	/** The security resource ID. */
+	String securityResourceId
 	
+	/** The communication version. */
+	String communicationVersion
+	
+	/** TODO: What is this? */
+	Object security
+		
 	// Constructors.	
 	UcdAgentRelay() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/applicationProcessRequest/UcdApplicationProcessRequest.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/applicationProcessRequest/UcdApplicationProcessRequest.groovy
@@ -72,6 +72,9 @@ class UcdApplicationProcessRequest extends UcdObject {
 	
 	/** The entry. TODO: What is this? */
 	Map entry
+	
+	/** TODO: What's this? */
+	Long warningCount
 
 	// Constructors.	
 	UcdApplicationProcessRequest() {

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcess/UcdComponentProcess.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcess/UcdComponentProcess.groovy
@@ -41,7 +41,10 @@ class UcdComponentProcess extends UcdObject {
 	
 	/** The path. */
 	String path
-	
+
+	/** The flag that indicates deleted. */
+	Boolean deleted
+		
 	// Constructors.	
 	UcdComponentProcess() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcess/UcdComponentProcessImport.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcess/UcdComponentProcessImport.groovy
@@ -41,7 +41,10 @@ class UcdComponentProcessImport {
 	
 	/** The configuration action type. TODO: What is this? Enumeration? */
 	String configActionType
-	
+
+	/** The flag to indicate deleted. */
+	Boolean deleted
+		
 	// Constructors.
 	UcdComponentProcessImport() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcessRequest/UcdComponentProcessRequest.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcessRequest/UcdComponentProcessRequest.groovy
@@ -3,9 +3,48 @@
  */
 package org.urbancode.ucadf.core.model.ucd.componentProcessRequest
 
+import org.urbancode.ucadf.core.model.ucd.agent.UcdAgent
+import org.urbancode.ucadf.core.model.ucd.application.UcdApplication
+import org.urbancode.ucadf.core.model.ucd.environment.UcdEnvironment
 import org.urbancode.ucadf.core.model.ucd.processRequest.UcdProcessRequestTrace
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 class UcdComponentProcessRequest extends UcdProcessRequestTrace {
+	/** The submitted time. */
+	Long submittedTime
+	
+	/** The trace ID. */
+	String traceId
+	
+	/** The user name. */
+	String userName
+	
+	/** The login name. */
+	String loginName
+	
+	/** The parent request ID. */
+	String parentRequestId
+	
+	/** The deployment request ID. */
+	String deploymentRequestId
+	
+	/** The start time. */
+	Long startTime
+
+	/** The associated application. */
+	UcdApplication application
+		
+	/** The associated environment. */
+	UcdEnvironment environment
+	
+	/** The associated agent. */
+	UcdAgent agent
+	
+	/** TODO: What's this? */
+	Object entry
+	
 	// Constructors.	
 	UcdComponentProcessRequest() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcessRequest/UcdComponentProcessRequestTask.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcessRequest/UcdComponentProcessRequestTask.groovy
@@ -3,6 +3,8 @@
  */
 package org.urbancode.ucadf.core.model.ucd.componentProcessRequest
 
+import org.urbancode.ucadf.core.model.ucd.application.UcdApplication
+import org.urbancode.ucadf.core.model.ucd.applicationProcessRequest.UcdApplicationProcessRequest
 import org.urbancode.ucadf.core.model.ucd.component.UcdComponent
 import org.urbancode.ucadf.core.model.ucd.processRequest.UcdProcessRequestTask
 
@@ -12,6 +14,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 class UcdComponentProcessRequestTask extends UcdProcessRequestTask {
 	/** The associated component process request. */
 	UcdComponentProcessRequest componentProcessRequest
+
+	/** The associated application process request. */
+	UcdApplicationProcessRequest applicationProcessRequest
+	
+	/** The associated application. */
+	UcdApplication application
 	
 	/** The associated component. */
 	UcdComponent component

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentTemplate/UcdComponentTemplate.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentTemplate/UcdComponentTemplate.groovy
@@ -83,6 +83,9 @@ class UcdComponentTemplate extends UcdSecurityTypeObject {
 	/** The extended security. */
 	UcdExtendedSecurity extendedSecurity
 	
+	/** The import configuration strategy. */
+	String importConfigurationStrategy
+	
 	// Constructors.	
 	UcdComponentTemplate() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentTemplate/UcdComponentTemplateImport.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentTemplate/UcdComponentTemplateImport.groovy
@@ -50,4 +50,7 @@ class UcdComponentTemplateImport extends UcdImport {
 	
 	/** The security resource ID. */
 	String securityResourceId
+	
+	/** The source configuration plugin name. */
+	String sourceConfigPluginName
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/exception/UcdInvalidValueException.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/exception/UcdInvalidValueException.groovy
@@ -8,18 +8,18 @@ import javax.ws.rs.core.Response
 import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfHandledException
 
 @Deprecated // Use UcAdfHandledException.
-class UcAdfInvalidValueException extends UcAdfHandledException {
+class UcdInvalidValueException extends UcAdfHandledException {
 	// Constructors.
-	UcAdfInvalidValueException(final String message) {
+	UcdInvalidValueException(final String message) {
 		super(message)
 	}
 	
-	UcAdfInvalidValueException(final Exception e) {
+	UcdInvalidValueException(final Exception e) {
 		this(e.getMessage())
 	}
 
 	// A web response exception.
-	UcAdfInvalidValueException(final Response response) {
+	UcdInvalidValueException(final Response response) {
 		this(getResponseErrorMessage(response))
 	}
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/group/UcdGroup.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/group/UcdGroup.groovy
@@ -17,4 +17,7 @@ class UcdGroup extends UcdObject {
 
 	/** The flag that indicates the group is enabled. */	
 	Boolean enabled
+	
+	/** TODO: What's this? */
+	Boolean isUserInGroup
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/processRequest/UcdProcessRequestTrace.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/processRequest/UcdProcessRequestTrace.groovy
@@ -79,6 +79,15 @@ class UcdProcessRequestTrace extends UcdObject {
 	// Added this to read the workflow step properties.
 	List<UcdProperty> stepProperties
 	List<UcdProperty> stepOutputProps
+
+	/** TODO: What's this? */
+	Long warningCount
+	
+	/** TODO: What's this? */
+	Object warningMessages
+
+	/** TODO: What's this? */
+	Object draft
 	
 	// Constructors.	
 	UcdProcessRequestTrace() {

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdPropDef.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdPropDef.groovy
@@ -67,6 +67,9 @@ abstract class UcdPropDef extends UcdObject {
 	/** The flag that indicates inherited. */
 	Boolean inherited
 
+	/** The index. */
+	Long index
+	
 	/**
 	 * A workaround to fix HTTP property definitions exported from an older version and imported to a new version.
 	 * @param application The application name or ID.

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdPropDefHttpSelect.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdPropDefHttpSelect.groovy
@@ -13,7 +13,7 @@ class UcdPropDefHttpSelect extends UcdPropDef {
 	/** The user name. */
 	String httpUsername
 	
-	/** The user password. *?
+	/** The user password. */
 	String httpPassword
 	
 	/** The user encrypted password. */

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdPropSheet.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdPropSheet.groovy
@@ -55,6 +55,9 @@ class UcdPropSheet extends UcdObject {
 	/** The security resource ID. */
 	String securityResourceId
 
+	/** TODO: What's this? */
+	Object propSheetDef
+	
 	UcdPropSheet() {
 	}
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdProperty.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/property/UcdProperty.groovy
@@ -27,6 +27,9 @@ class UcdProperty extends UcdObject {
 	/** The flag that indicates inherited. */
 	Boolean inherited = false
 
+	/** TODO: What is this? */
+	Object index
+	
 	// Constructors.	
 	UcdProperty() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/security/UcdExtendedSecurityTeam.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/security/UcdExtendedSecurityTeam.groovy
@@ -5,6 +5,7 @@ package org.urbancode.ucadf.core.model.ucd.security
 
 import org.urbancode.ucadf.core.model.ucd.general.UcdObject
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/security/UcdSecurityPermissionProperties.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/security/UcdSecurityPermissionProperties.groovy
@@ -10,138 +10,191 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class UcdSecurityPermissionProperties extends UcdObject {
-    public final static String PERMISSION_CREATECOMPONENTSFROMTEMPLATE = "Create Components From Template"
-    public final static String PERMISSION_CREATEENVIRONMENTSFROMTEMPLATE = "Create Environments From Template"
-	public final static String PERMISSION_EXECUTEONRESOURCES = "Execute on Resources"
-	public final static String PERMISSION_VIEWRESOURCES = "View Resources"
-	public final static String PERMISSION_EXECUTEONAGENTS = "Execute on Agents"
-	public final static String PERMISSION_VIEWAGENTS = "View Agents"
-	public final static String PERMISSION_MANAGESNAPSHOTS = "Manage Snapshots"
-	public final static String PERMISSION_DELETESNAPSHOTS = "Delete Snapshots"
-	
-	// System Configuration actions added in 7.x.
-	public final static String PERMISSION_EDITNETWORKSETTINGS = "Edit Network Settings"
-	public final static String PERMISSION_MANAGEAUDITLOG = "Manage Audit Log"
-	public final static String PERMISSION_MANAGEBLUEPRINTDESIGNERINTEGRATIONS = "Manage Blueprint Designer Integrations"
-	public final static String PERMISSION_MANAGEDIAGNOSTICS = "Manage Diagnostics"
-	public final static String PERMISSION_MANAGELOGGINGSETTINGS = "Manage Logging Settings"
-	public final static String PERMISSION_MANAGENOTIFICATIONSCHEMES = "Manage Notification Schemes"
-	public final static String PERMISSION_MANAGESTATUSES = "Manage Statuses"
-	public final static String PERMISSION_MANAGESYSTEMPROPERTIES = "Manage System Properties"
-	public final static String PERMISSION_RELEASELOCKS = "Release Locks"
-	public final static String PERMISSION_VIEWAUDITLOG = "View Audit Log"
-	public final static String PERMISSION_VIEWLOCKS = "View Locks"
-	public final static String PERMISSION_VIEWNETWORKSETTINGS = "View Network Settings"
-	public final static String PERMISSION_VIEWOUTPUTLOG = "View Output Log"
-	
-    public final static List<String> ACTIONNAMESNOTIN61 = [
-        PERMISSION_CREATECOMPONENTSFROMTEMPLATE,
-        PERMISSION_CREATEENVIRONMENTSFROMTEMPLATE,
-		PERMISSION_EXECUTEONRESOURCES,
-		PERMISSION_EXECUTEONAGENTS,
-		PERMISSION_DELETESNAPSHOTS
-    ]
-	
-	public final static List<String> ACTIONNAMESNOTIN62 = [
-		PERMISSION_DELETESNAPSHOTS
+	// When an export is done from an older version we want to add any permissions to it that will exist in a newer version and that need to be set to true by default to maintain the same behavior.
+	// We do this by looking at a permission that is being exported and adding additional new permissions that are implied from that old permission.
+	private static Map<String, List<String>> PERMISSIONSTOADD = [
+		"Manage Versions": [ "Manage Version Status" ]
 	]
 
+	// Return a list of new permissions to add to export if an old permission exists.
+	public static List<String> permissionsToAdd(final String oldPermission) {
+		List<String> newPermissions = []
+		
+		if (PERMISSIONSTOADD.containsKey(oldPermission)) {
+			newPermissions = PERMISSIONSTOADD.get(oldPermission)
+		}
+		
+		return newPermissions
+	}	
+	
 	// Common.
 	Boolean read
+	
 	@JsonProperty("Delete")
 	Boolean delete
+	
 	@JsonProperty("Edit Basic Settings")
 	Boolean editBasicSettings
+	
 	@JsonProperty("Manage Processes")
 	Boolean manageProcesses
+	
 	@JsonProperty("Manage Properties")
 	Boolean manageProperties
+	
 	@JsonProperty("Manage Teams")
 	Boolean manageTeams
+	
 	@JsonProperty("Create Resources")
 	Boolean createResources
+	
+	@JsonProperty("Approve Promotion")
+	Boolean approvePromotion
+	
+	@JsonProperty("write")
+	Boolean write
+	
+	@JsonProperty("Manage Process Lock")
+	Boolean manageProcessLock
 
 	// Agents.
-	@JsonProperty(value=UcdSecurityPermissionProperties.PERMISSION_VIEWAGENTS)
+	@JsonProperty("View Agents")
 	Boolean viewAgents
+	
 	@JsonProperty("Add to Agent Pool")
 	Boolean addToAgentPool
+	
 	@JsonProperty("Manage Impersonation")
 	Boolean manageImpersonation
+	
 	@JsonProperty("Manage Version Imports")
 	Boolean manageVersionImports
 	
+	@JsonProperty("Execute on Agents")
+	Boolean executeOnAgents
+	
+	@JsonProperty("Install Remote Agents")
+	Boolean installRemoteAgents
+	
+	@JsonProperty("Manage Licenses")
+	Boolean manageLicenses
+	
+	@JsonProperty("Upgrade Agents")
+	Boolean upgradeAgents
+
 	// Agent Pools.
 	@JsonProperty("Create Agent Pools")
 	Boolean createAgentPools
+	
 	@JsonProperty("Manage Pool Members")
 	Boolean managePoolMembers
+	
 	@JsonProperty("View Agent Pools")
 	Boolean viewAgentPools
+
+	// Agent relays.
+	@JsonProperty("View Agent Relays")
+	Boolean viewAgentRelays
 
 	// Applications.
 	@JsonProperty("Create Applications")
 	Boolean createApplications
+	
+    @JsonProperty("Create Applications From Template")
+    Boolean createApplicationsFromTemplate
+	
 	@JsonProperty("View Applications")
 	Boolean viewApplications
+	
 	@JsonProperty("Manage Blueprints")
 	Boolean manageBlueprints
+	
 	@JsonProperty("Manage Components")
 	Boolean manageComponents
+	
 	@JsonProperty("Manage Environments")
 	Boolean manageEnvironments
+	
 	@JsonProperty("Delete Snapshots")
 	Boolean deleteSnapshots
+	
 	@JsonProperty("Manage Snapshots")
 	Boolean manageSnapshots
+	
 	@JsonProperty("Run Component Processes")
 	Boolean runComponentProcesses
 
 	// Components.
 	@JsonProperty("Create Components")
 	Boolean createComponents
-    @JsonProperty(value=UcdSecurityPermissionProperties.PERMISSION_CREATECOMPONENTSFROMTEMPLATE)
+	
+    @JsonProperty("Create Components From Template")
     Boolean createComponentsFromTemplate
+	
 	@JsonProperty("View Components")
 	Boolean viewComponents
+	
 	@JsonProperty("Edit Components")
 	Boolean editComponents
+	
 	@JsonProperty("Manage Configuration Templates")
 	Boolean manageConfigurationTemplates
+	
 	@JsonProperty("Manage Versions")
 	Boolean manageVersions
+	
+	@JsonProperty("Manage Version Status")
+	Boolean manageVersionStatus
+
+	// Component templates
+	@JsonProperty("Create Component Templates")
+	Boolean createComponentTemplates
+	
+	@JsonProperty("View Component Templates")
+	Boolean viewComponentTemplates
 
 	// Environments.
 	@JsonProperty("Create Environments")
 	Boolean createEnvironments
-    @JsonProperty(value=UcdSecurityPermissionProperties.PERMISSION_CREATEENVIRONMENTSFROMTEMPLATE)
+
+	@JsonProperty("Create Environments From Template")
     Boolean createEnvironmentsFromTemplate
+	
 	@JsonProperty("Execute on Environments")
 	Boolean executeOnEnvironments
+	
 	@JsonProperty("Manage Approval Processes")
 	Boolean manageApprovalProcesses
+	
 	@JsonProperty("Manage Base Resources")
 	Boolean manageBaseResources
+	
 	@JsonProperty("View Environments")
 	Boolean viewEnvironments
 
 	// Resources.
-	@JsonProperty(value=UcdSecurityPermissionProperties.PERMISSION_VIEWRESOURCES)
+	@JsonProperty("View Resources")
 	Boolean viewResources
-	@JsonProperty(value=UcdSecurityPermissionProperties.PERMISSION_EXECUTEONRESOURCES)
+	
+	@JsonProperty("Execute on Resources")
 	Boolean executeOnResources
+	
 	@JsonProperty("Manage Children")
 	Boolean manageChildren
+	
 	@JsonProperty("Map to Environments")
 	Boolean mapToEnvironments
 
 	// Generic Processes.
 	@JsonProperty("execute")
 	Boolean execute
+	
 	@JsonProperty("Create Processes")
 	Boolean createProcesses
+	
 	@JsonProperty("Execute Processes")
 	Boolean executeProcesses
+	
 	@JsonProperty("View Processes")
 	Boolean viewProcesses
 

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/snapshot/UcdSnapshotVersions.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/snapshot/UcdSnapshotVersions.groovy
@@ -13,6 +13,9 @@ class UcdSnapshotVersions extends UcdComponent {
 	/** The desired versions. */
 	List<UcdVersion> desiredVersions
 	
+	/** Flag that indicates children. */
+	Boolean children
+	
 	// Constructors.	
 	UcdSnapshotVersions() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/snapshotConfiguration/UcdSnapshotConfigurationApplicationProcess.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/snapshotConfiguration/UcdSnapshotConfigurationApplicationProcess.groovy
@@ -1,14 +1,23 @@
 package org.urbancode.ucadf.core.model.ucd.snapshotConfiguration
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.urbancode.ucadf.core.model.ucd.applicationProcess.UcdApplicationProcessInventoryManagementTypeEnum
 import org.urbancode.ucadf.core.model.ucd.applicationProcess.UcdApplicationProcessOfflineAgentHandlingEnum
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class UcdSnapshotConfigurationApplicationProcess extends UcdSnapshotConfigurationProcess implements UcdSnapshotConfigurationTypeByClassName {
 	public final static String CLASS_NAME = "ApplicationProcess"
-	
+
+	/** The inventory management type. */	
 	UcdApplicationProcessInventoryManagementTypeEnum inventoryManagementType
+	
+	/** The offline agent handling. */
 	UcdApplicationProcessOfflineAgentHandlingEnum offlineAgentHandling
+	
+	/** The flag that indicates deleted. */
 	Boolean deleted
+	
+	/** TODO: What's this? */
+	String metadataType
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/system/UcdSystemConfiguration.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/system/UcdSystemConfiguration.groovy
@@ -62,6 +62,14 @@ class UcdSystemConfiguration extends UcdObject {
 	String defaultLocale
 	String defaultSnapshotLockType
 	Boolean envCompPropsOverrideEnvProps
+	Boolean safeEditEnabled
+	Boolean allowProcessLocking
+	Boolean requireProcessLocking
+	Boolean maintenanceModeEnabled
+	Long keepMeLoggedInHours
+	Boolean deleteEnvResources
+	Boolean vcCompressionUpgradeEnabled
+	Boolean vcCompressionUpgradeCompleted
 	
 	// Constructors.
 	UcdSystemConfiguration() {

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/user/UcdUser.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/user/UcdUser.groovy
@@ -47,6 +47,9 @@ class UcdUser extends UcdObject {
 	/** The list of associated groups. */
 	List<UcdGroup> groups
 
+	/** The last login date. */
+	Long lastLoginDate
+	
 	// Constructors.	
 	UcdUser() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/workflow/UcdWorkflowApplicationProcessRequest.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/workflow/UcdWorkflowApplicationProcessRequest.groovy
@@ -11,6 +11,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 class UcdWorkflowApplicationProcessRequest extends UcdApplicationProcessRequest implements UcdWorkflowProcessRequest {
 	String processRequestType = TYPE_APPLICATION
 
+	/** TODO: What's this? */
+	Boolean executable
+	
 	// Constructors.	
 	UcdWorkflowApplicationProcessRequest() {
 	}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/workflow/UcdWorkflowGenericProcessRequest.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/workflow/UcdWorkflowGenericProcessRequest.groovy
@@ -4,12 +4,23 @@
 package org.urbancode.ucadf.core.model.ucd.workflow
 
 import org.urbancode.ucadf.core.model.ucd.genericProcessRequest.UcdGenericProcessRequest
+import org.urbancode.ucadf.core.model.ucd.resource.UcdResource
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class UcdWorkflowGenericProcessRequest extends UcdGenericProcessRequest implements UcdWorkflowProcessRequest {
+	/** The process request type. */
 	String processRequestType = TYPE_GENERIC
+	
+	/** TODO: What's this? */
+	Long warningCount
+
+	/** TODO: What's this? */
+	Boolean executable
+	
+	/** TODO: What's this? */
+	UcdResource resource
 	
 	// Constructors.	
 	UcdWorkflowGenericProcessRequest() {


### PR DESCRIPTION
…ersions.

Add Manage Version Status permission if Edit components permission is added to be forward compatible wwith 7.0.5.
Updated environment actions test to create one environment of each color.
Remove obsolete UCD version processing.
Added failIfNotFound write option to write security permissions.
Ignore 500 errors for certain opertions that don't handle already exists properly.
Change UcAdfObject to use UcAdfObjectMapper to mask.
Added UcAdfMask introspector.
Changed loop controls to use UcAdfObject instead of UcdObject.