### PR TITLE
Changes to set component template properties timing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<groovy-version>3.0.6</groovy-version>
-		<junit-version>5.7.0</junit-version>
-		<jersey-version>2.29.1</jersey-version>
+		<groovy-version>3.0.7</groovy-version>
+		<junit-jupiter-version>5.7.0</junit-jupiter-version>
+		<jersey-version>2.30.1</jersey-version>
 		<jackson-databind-version>2.11.0</jackson-databind-version>
 	</properties>
 
@@ -318,27 +318,34 @@
 			<version>${groovy-version}</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<!-- Use later Junit than that included in Jupiter. -->
+		<dependency>
+		    <groupId>junit</groupId>
+		    <artifactId>junit</artifactId>
+		    <version>4.13.1</version>
+		</dependency>
 		
-		<!-- Junit 5 dependencies. -->
+		<!-- Junit Jupiter 5 dependencies. -->
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-api</artifactId>
-		    <version>${junit-version}</version>
+		    <version>${junit-jupiter-version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-params</artifactId>
-		    <version>${junit-version}</version>
+		    <version>${junit-jupiter-version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-migrationsupport</artifactId>
-		    <version>${junit-version}</version>
+		    <version>${junit-jupiter-version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter-engine</artifactId>
-		    <version>${junit-version}</version>
+		    <version>${junit-jupiter-version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.junit.platform</groupId>
@@ -404,6 +411,12 @@
 			<artifactId>jersey-hk2</artifactId>
 			<version>${jersey-version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.connectors</groupId>
+			<artifactId>jersey-apache-connector</artifactId>
+			<version>${jersey-version}</version>
+		</dependency>
+	
 		<dependency>
 			<groupId>jakarta.activation</groupId>
 			<artifactId>jakarta.activation-api</artifactId>

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucadf/diff/UcAdfDiff.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucadf/diff/UcAdfDiff.groovy
@@ -107,6 +107,7 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdApplicationProcess> appProcesses1 = actionsRunner.runAction([
 			action: UcdGetApplicationProcesses.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			application: name1,
 			full: true
 		])
@@ -114,6 +115,7 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdApplicationProcess> appProcesses2 = actionsRunner.runAction([
 			action: UcdGetApplicationProcesses.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			application: name2,
 			full: true
 		])
@@ -138,6 +140,7 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdComponentProcess> compProcesses2 = actionsRunner.runAction([
 			action: UcdGetComponentProcesses.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			component: name2
 		])
 
@@ -156,6 +159,7 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdProperty> compProperties1 = actionsRunner.runAction([
 			action: UcdGetComponentProperties.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			component: name1,
 			excludeInherited: true
 		])
@@ -163,6 +167,7 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdProperty> compProperties2 = actionsRunner.runAction([
 			action: UcdGetComponentProperties.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			component: name2,
 			excludeInherited: true
 		])
@@ -182,12 +187,14 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdComponentProcess> compTemplateProcesses1 = actionsRunner.runAction([
 			action: UcdGetComponentTemplateProcesses.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			componentTemplate: name1
 		])
 		
 		List<UcdComponentProcess> compTemplateProcesses2 = actionsRunner.runAction([
 			action: UcdGetComponentTemplateProcesses.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			componentTemplate: name2
 		])
 
@@ -206,12 +213,14 @@ class UcAdfDiff extends UcAdfAction {
 		List<UcdProperty> compTemplateProperties1 = actionsRunner.runAction([
 			action: UcdGetComponentProperties.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			componentTemplate: name1
 		])
 		
 		List<UcdProperty> compTemplateProperties2 = actionsRunner.runAction([
 			action: UcdGetComponentProperties.getSimpleName(),
 			actionInfo: false,
+			actionVerbose: false,
 			componentTemplate: name2
 		])
 

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucadf/general/UcAdfExtractFile.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucadf/general/UcAdfExtractFile.groovy
@@ -7,19 +7,22 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
 import org.urbancode.ucadf.core.actionsrunner.UcAdfAction
+import org.urbancode.ucadf.core.actionsrunner.UcAdfActionsRunner
 import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
 
 class UcAdfExtractFile extends UcAdfAction {
 	/** The extract file type. */
-	enum ExtractFileType {
-		ZIP
+	enum ExtractFileTypeEnum {
+		ZIP,
+		TAR
 	}
 	
 	// Action properties.
 	/** The extract file name. */
 	String fileName
 
-	ExtractFileType fileType = ExtractFileType.ZIP
+	/** The file extract type. Default is ZIP. */
+	ExtractFileTypeEnum fileType = ExtractFileTypeEnum.ZIP
 		
 	/** The extract directory name. */
 	String extractDirName
@@ -54,9 +57,16 @@ class UcAdfExtractFile extends UcAdfAction {
 			extractDir.mkdirs()
 
 			// Currently only supports Zip file type.
-			if (ExtractFileType.ZIP.equals(fileType)) {
+			if (ExtractFileTypeEnum.ZIP.equals(fileType)) {
 				// Unzip the file.
 				unzip(
+					extractFile, 
+					extractDir,
+					actionVerbose
+				)	
+			} else if (ExtractFileTypeEnum.TAR.equals(fileType)) {
+				// Untar the file.
+				untar(
 					extractFile, 
 					extractDir,
 					actionVerbose
@@ -135,5 +145,28 @@ class UcAdfExtractFile extends UcAdfAction {
 		} catch (IOException e) {
 			e.printStackTrace()
 		}
+	}
+	
+	// Extract a TAR file.	
+	public static untar(
+		final File extractFile,
+		final File extractDir,
+		final Boolean verbose) {
+
+		if (verbose) {
+			println "Untar file [$extractFile] to directory [$extractDir]."
+		}
+
+		// Construct the command list.
+		List<String> commandList = [ "tar", "-xvf", extractFile.toString(), "-C", extractDir.toString() ]
+		
+		// Run the native tar command.
+		new UcAdfActionsRunner().runAction([
+			action: UcAdfExecuteCommand.getSimpleName(),
+			actionInfo: false,
+			actionVerbose: false,
+			commandList: commandList,
+			showOutput: true
+		])
 	}
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/agent/UcdDeleteAgent.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/agent/UcdDeleteAgent.groovy
@@ -43,7 +43,7 @@ class UcdDeleteAgent extends UcAdfAction {
 			logDebug("target=$target")
 			
 			// Had to add logic to handle concurrency issue discovered in UCD 7.0.1.2.
-			final Integer MAXATTEMPTS = 5
+			final Integer MAXATTEMPTS = 10
 			for (Integer iAttempt = 1; iAttempt <= MAXATTEMPTS; iAttempt++) {
 				Response response = target.request(MediaType.APPLICATION_JSON).delete()
 				response.bufferEntity()
@@ -62,9 +62,10 @@ class UcdDeleteAgent extends UcAdfAction {
 				} else {
 					String responseStr = response.readEntity(String.class)
 					logVerbose(responseStr)
-					if ((responseStr ==~ /.*bulk manipulation query.*/ || responseStr ==~ /.*another transaction.*/) && iAttempt < MAXATTEMPTS) {
-						logVerbose("Attempt $iAttempt failed. Waiting to try again.")
-						Thread.sleep(2000)
+					if ((responseStr ==~ /.*bulk manipulation query.*/ || responseStr ==~ /.*transaction.*/) && iAttempt < MAXATTEMPTS) {
+						logWarn("Attempt $iAttempt failed. Waiting to try again.")
+						Random rand = new Random(System.currentTimeMillis())
+						Thread.sleep(rand.nextInt(2000))
 					} else {
 						throw new UcAdfInvalidValueException(response)
 					}

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/applicationProcess/UcdGetApplicationProcessChangeLog.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/applicationProcess/UcdGetApplicationProcessChangeLog.groovy
@@ -1,0 +1,69 @@
+/**
+ * This action gets an application processes change log.
+ */
+package org.urbancode.ucadf.core.action.ucd.applicationProcess
+
+import javax.ws.rs.client.WebTarget
+import javax.ws.rs.core.GenericType
+import javax.ws.rs.core.Response
+
+import org.urbancode.ucadf.core.actionsrunner.UcAdfAction
+import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
+import org.urbancode.ucadf.core.model.ucd.applicationProcess.UcdApplicationProcess
+import org.urbancode.ucadf.core.model.ucd.applicationProcess.UcdApplicationProcessCommit
+import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+
+class UcdGetApplicationProcessChangeLog extends UcAdfAction {
+	// Action properties.
+	/** The application name or ID. If not specified then process must be an ID. */
+	String application = ""
+	
+	/** The process name or ID. */
+	String process
+
+	/** The version of the process. Default is -1. */	
+	Long version = -1
+	
+	/** The flag that indicates fail if the application process is not found. Default is true. */
+	Boolean failIfNotFound = true
+	
+	/**
+	 * Runs the action.	
+	 * @return The list of application process log objects.
+	 */
+	@Override
+	public List<UcdApplicationProcessCommit> run() {
+		// Validate the action properties.
+		validatePropsExistExclude([ 'application' ])
+
+		logVerbose("Getting application [$application] process [$process] change log.")
+
+		List<UcdApplicationProcessCommit> ucdApplicationProcessCommits
+			
+		String processId = process
+		if (!UcdObject.isUUID(process)) {
+			UcdApplicationProcess ucdApplication = actionsRunner.runAction([
+				action: UcdGetApplicationProcess.getSimpleName(),
+				actionInfo: false,
+				application: application,
+				process: process,
+				failIfNotFound: failIfNotFound
+			])
+			processId = ucdApplication.getId()
+		}
+		
+		// Get the basic application process information.
+		WebTarget target = ucdSession.getUcdWebTarget().path("/rest/deploy/applicationProcess/{processId}/changelog")
+			.resolveTemplate("processId", processId)
+		logDebug("target=$target")
+
+		Response response = target.request().get()
+		if (response.getStatus() == 200) {
+			ucdApplicationProcessCommits = response.readEntity(new GenericType<List<UcdApplicationProcessCommit>>(){})
+		} else {
+			throw new UcAdfInvalidValueException(response)
+		}
+		
+		return ucdApplicationProcessCommits
+	}
+}

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/applicationProcess/UcdGetApplicationProcesses.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/applicationProcess/UcdGetApplicationProcesses.groovy
@@ -39,6 +39,7 @@ class UcdGetApplicationProcesses extends UcAdfAction {
 			UcdApplication ucdApplication = actionsRunner.runAction([
 				action: UcdGetApplication.getSimpleName(),
 				actionInfo: false,
+				actionVerbose: false,
 				application: application,
 				failIfNotFound: true
 			])

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/componentProcessRequest/UcdGetComponentProcessRequestTaskCompletionProperties.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/componentProcessRequest/UcdGetComponentProcessRequestTaskCompletionProperties.groovy
@@ -8,6 +8,7 @@ import java.util.regex.Matcher
 
 import org.urbancode.ucadf.core.action.ucd.user.UcdGetUser
 import org.urbancode.ucadf.core.actionsrunner.UcAdfAction
+import org.urbancode.ucadf.core.model.ucadf.UcAdfObject
 import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
 import org.urbancode.ucadf.core.model.ucd.componentProcessRequest.UcdComponentProcessRequest
 import org.urbancode.ucadf.core.model.ucd.componentProcessRequest.UcdComponentProcessRequestTask
@@ -111,7 +112,7 @@ class UcdGetComponentProcessRequestTaskCompletionProperties extends UcAdfAction 
 	}
 
 	/** This class returns task information. */
-	static public class TaskReturn {
+	static public class TaskReturn extends UcAdfObject {
 		String taskCompletedBy
 		String taskCompletedByDisplayName
 		String taskCompletedOn

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/componentTemplate/UcdSetComponentTemplateProperties.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/componentTemplate/UcdSetComponentTemplateProperties.groovy
@@ -64,19 +64,20 @@ class UcdSetComponentTemplateProperties extends UcAdfAction {
 			}
 	
 			if (ucdExistingProperty) {
-				// Update the property.
+				logDebug("Update existing property.")
 				target = ucdSession.getUcdWebTarget().path("/property/propSheet/componentTemplates{templateLookup}propSheet.-1/propValues/{propName}")
 					.resolveTemplateFromEncoded("templateLookup", templateId)
 					.resolveTemplate("propName", ucdProperty.getName())
 					
 				requestMap.put("existingId", ucdExistingProperty.getId())
 			} else {
-				// Add the property.
+				logDebug("Add property.")
 				target = ucdSession.getUcdWebTarget().path("/property/propSheet/componentTemplates{templateLookup}propSheet.-1/propValues")
 					.resolveTemplateFromEncoded("templateLookup", templateId)
 			}
 			logDebug("target=$target")
-	
+			logDebug("requestMap=$requestMap")
+			
 			JsonBuilder jsonBuilder = new JsonBuilder(requestMap)
 			
 			// Had to put Version in the header to avoid 409 status errors		
@@ -87,8 +88,8 @@ class UcdSetComponentTemplateProperties extends UcAdfAction {
 			if (response.getStatus() == 200) {
 				logVerbose("Property [${ucdProperty.getName()}] set.")
 				
-				// Intentionally sleeping because of UCD 6.1 problems if the component template properties are updated too quickly in succession.
-				Thread.sleep(1000)
+				// Intentionally sleeping because of problems if the component template properties are updated too quickly in succession.
+				Thread.sleep(1500)
 			} else {
 	            throw new UcAdfInvalidValueException(response)
 			}

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/environment/UcdGetEnvironmentPropSheet.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/environment/UcdGetEnvironmentPropSheet.groovy
@@ -1,0 +1,69 @@
+/**
+ * This action gets an application property sheet.
+ */
+package org.urbancode.ucadf.core.action.ucd.environment
+
+import javax.ws.rs.client.WebTarget
+import javax.ws.rs.core.Response
+
+import org.urbancode.ucadf.core.actionsrunner.UcAdfAction
+import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
+import org.urbancode.ucadf.core.model.ucd.environment.UcdEnvironment
+import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+import org.urbancode.ucadf.core.model.ucd.property.UcdPropSheet
+
+class UcdGetEnvironmentPropSheet extends UcAdfAction {
+	// Action properties.
+	/** The application name or ID. */
+	String application
+	
+	/** The environment name or ID. */
+	String environment
+
+	/** The property sheet version. Default is -1 (latest). */
+	Integer versionNumber = -1
+	
+	/**
+	 * Runs the action.
+	 * @return The property sheet object.
+	 */
+	public UcdPropSheet run() {
+		// Validate the action properties.
+		validatePropsExist()
+
+		UcdPropSheet ucdPropSheet
+		String applicationId = application
+		String environmentId = environment
+		
+		// If UUIDs weren't provided then get the environment information.
+		if (!UcdObject.isUUID(application) || !UcdObject.isUUID(environment)) {
+			UcdEnvironment ucdEnvironment = actionsRunner.runAction([
+				action: UcdGetEnvironment.getSimpleName(),
+				actionInfo: false,
+				actionVerbose: false,
+				application: application,
+				environment: environment,
+				withDetails: true
+			])
+			applicationId = ucdEnvironment.getApplication().getId()
+			environmentId = ucdEnvironment.getId()
+		}
+		
+		WebTarget target = ucdSession.getUcdWebTarget()
+			.path("/property/propSheet/applications&{applicationId}&environments&{environmentId}&propSheet.{versionNumber}")
+			.resolveTemplate("applicationId", applicationId)
+			.resolveTemplate("environmentId", environmentId)
+			.resolveTemplate("versionNumber", versionNumber.toString()
+		)
+		logDebug("target=$target")
+		
+		Response response = target.request().get()
+		if (response.getStatus() == 200) {
+			ucdPropSheet = response.readEntity(UcdPropSheet.class)
+		} else {
+            throw new UcAdfInvalidValueException(response)
+		}
+		
+		return ucdPropSheet
+	}
+}

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/plugin/UcdDeleteAutomationPlugin.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/plugin/UcdDeleteAutomationPlugin.groovy
@@ -54,7 +54,7 @@ class UcdDeleteAutomationPlugin extends UcAdfAction {
 				logDebug("target=$target")
 				
 				// Logic to handle concurrency issue that might exist in some UCD versions.
-				final Integer MAXATTEMPTS = 5
+				final Integer MAXATTEMPTS = 10
 				for (Integer iAttempt = 1; iAttempt <= MAXATTEMPTS; iAttempt++) {
 					Response response = target.request(MediaType.APPLICATION_JSON).delete()
 					response.bufferEntity()
@@ -74,7 +74,7 @@ class UcdDeleteAutomationPlugin extends UcAdfAction {
 						String responseStr = response.readEntity(String.class)
 						logVerbose(responseStr)
 						if (responseStr ==~ /.*bulk manipulation query.*/ && iAttempt < MAXATTEMPTS) {
-							logVerbose("Attempt $iAttempt failed. Waiting to try again.")
+							logWarn("Attempt $iAttempt failed. Waiting to try again.")
 							Thread.sleep(2000)
 						} else {
 							throw new UcAdfInvalidValueException(response)

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/resource/UcdCreateComponentResource.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/resource/UcdCreateComponentResource.groovy
@@ -46,55 +46,82 @@ class UcdCreateComponentResource extends UcAdfAction {
 		// Validate the action properties.
 		validatePropsExist()
 		
+		Boolean created = false
+		
 		// If no parent path was provided then split the provided path to get the parent.
 		name = resource
 		if (!parent) {
 			(parent, name) = UcdResource.getParentPathAndName(resource)
 		}
 
-		// Attempt to create the resource. If it encounters a unique result error then try to delete it and try to create it again.
-		if (createResource(false)) {
-			// Attempt to delete the resource.
-			actionsRunner.runAction([
-				action: UcdDeleteResource.getSimpleName(),
-				actionInfo: true,
-				actionVerbose: true,
-				resource: resource
-			])
-			
-			// Attempt to create the resource again.
-			createResource(true)
-		}
+		// See if the resource already exists.
+		WebTarget target = ucdSession.getUcdWebTarget().path("/cli/resource/info")
+			.queryParam("resource", "${parent}/${name}")
+		logDebug("target=$target")
 
-		// If the resource was created then attempt to get it to make sure there's no unique result problem.
-		if (created) {
-			WebTarget target = ucdSession.getUcdWebTarget().path("/cli/resource/info")
-				.queryParam("resource", "${parent}/${name}")
-			logDebug("target=$target")
-		
-			Response response = target.request().get()
-			
-			// If the get encounters a unique result error then delete the resource and create it again.
-			if (response.getStatus() == 400 && response.readEntity(String.class).matches(/.*query did not return a unique result.*/)) {
-				// Attempt to delete the resource.
-				actionsRunner.runAction([
-					action: UcdDeleteResource.getSimpleName(),
-					actionInfo: true,
-					actionVerbose: true,
-					resource: resource
-				])
-				
-				// Attempt to create the resource again.
-				createResource(true)
+		Response response = target.request().get()
+	
+		if (response.getStatus() == 200) {
+			String message = "Resource [${parent}/${name}] already exists."
+			if (failIfExists) {
+				throw new UcAdfInvalidValueException(message)
+			} else {
+				logVerbose(message)
 			}
+		} else {
+			createResourceWithRetry()
+			created = true
 		}
 		
 		return created
 	}
+
+	// Logic to handle concurrency issues.
+	public createResourceWithRetry() {
+		Boolean uniqueResultError
+		Boolean alreadyExists
+		final Integer MAXATTEMPTS = 20
+		for (Integer iAttempt = 1; iAttempt <= MAXATTEMPTS; iAttempt++) {
+			// Attempt to create the resourece.
+			(alreadyExists, uniqueResultError) = createResource()
+			if (alreadyExists) {
+				break
+			}
+			
+			if (!uniqueResultError) {
+				// Attempt to retrieve the newly created resource.
+				uniqueResultError = retrieveNewResource()
+			}
+
+			// If no error then quit.
+			if (!uniqueResultError) {
+				break
+			}
+
+			logVerbose("A unique result error was encountered on attempt $iAttempt. Trying again.")
+
+			// Attempt to delete the resource.
+			actionsRunner.runAction([
+				action: UcdDeleteResource.getSimpleName(),
+				actionInfo: false,
+				actionVerbose: false,
+				resource: resource
+			])
+
+			// Sleep for a random period of time.
+			Random rand = new Random(System.currentTimeMillis())
+			Thread.sleep(rand.nextInt(2000))
+		}
+		
+		if (uniqueResultError) {
+			throw new UcAdfInvalidValueException("Errors were encountered while trying to create resource.")
+		}
+	}
 	
 	// Attempt to create the resource.	
-	public Boolean createResource(final Boolean retry) {
+	public Object createResource() {
 		Boolean uniqueResultError = false
+		Boolean alreadyExists = false
 		
 		logVerbose("Creating component resource [$parent/$name].")
 
@@ -134,11 +161,31 @@ class UcdCreateComponentResource extends UcAdfAction {
 				} else {
 					logVerbose("Resource [$parent/$name] already exists.")
 				}
-			} else if (!retry && response.getStatus() == 400 && errMsg.matches(/.*query did not return a unique result.*/)) {
+			} else if (response.getStatus() == 400 && errMsg.matches(/.*query did not return a unique result.*/)) {
 				uniqueResultError = true
 			} else {
 				throw new UcAdfInvalidValueException(errMsg)
 			}
+		}
+		
+		return [alreadyExists, uniqueResultError]
+	}
+	
+	// Attempt to retrieve the newly created resource.
+	public Boolean retrieveNewResource() {
+		Boolean uniqueResultError = false
+		
+		WebTarget target = ucdSession.getUcdWebTarget().path("/cli/resource/info")
+			.queryParam("resource", "${parent}/${name}")
+			
+		logDebug("target=$target")
+	
+		Response response = target.request().get()
+		
+		// If the get encounters a unique result error then delete the resource and create it again.
+		if (response.getStatus() != 200) {
+			logWarn("Attempt to retrieve resource returned ${response.getStatus()}.")
+			uniqueResultError = true
 		}
 		
 		return uniqueResultError

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/resource/UcdSetResourceProperties.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/resource/UcdSetResourceProperties.groovy
@@ -51,7 +51,7 @@ class UcdSetResourceProperties extends UcAdfAction {
 		Response response
 
 		// Had to add logic to handle concurrency issue discovered in UCD 7.x.
-		final Integer MAXATTEMPTS = 5
+		final Integer MAXATTEMPTS = 10
 		for (Integer iAttempt = 1; iAttempt <= MAXATTEMPTS; iAttempt++) {
 			if (ucdSession.compareVersion(UcdSession.UCDVERSION_70) >= 0) {
 				// Newer API.
@@ -89,10 +89,11 @@ class UcdSetResourceProperties extends UcAdfAction {
 			if (response.getStatus() == 200) {
 				break
 			} else {
-				logInfo response.readEntity(String.class)
+				logInfo(response.readEntity(String.class))
 				if (response.getStatus() == 409 && iAttempt < MAXATTEMPTS) {
-					logInfo "Attempt $iAttempt failed. Waiting to try again."
-					Thread.sleep(2000)
+					logWarn("Attempt $iAttempt failed. Waiting to try again.")
+					Random rand = new Random(System.currentTimeMillis())
+					Thread.sleep(rand.nextInt(2000))
 				} else {
 					throw new UcAdfInvalidValueException(response)
 				}

--- a/src/main/groovy/org/urbancode/ucadf/core/action/ucd/snapshot/UcdGetSnapshotVersions.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/action/ucd/snapshot/UcdGetSnapshotVersions.groovy
@@ -7,7 +7,6 @@ import javax.ws.rs.client.WebTarget
 import javax.ws.rs.core.GenericType
 import javax.ws.rs.core.Response
 
-import org.urbancode.ucadf.core.action.ucd.team.UcdGetTeamUsers.ReturnAsEnum
 import org.urbancode.ucadf.core.actionsrunner.UcAdfAction
 import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
 import org.urbancode.ucadf.core.model.ucd.snapshot.UcdSnapshotVersions
@@ -18,7 +17,7 @@ class UcdGetSnapshotVersions extends UcAdfAction {
 		/** Return as a list of componentName: versionName maps. */
 		LIST,
 		
-		/** Return as a map having the team name as the key. */
+		/** Return as a map having the component name as the key. */
 		MAPBYNAME
 	}
 	

--- a/src/main/groovy/org/urbancode/ucadf/core/actionsrunner/UcAdfAction.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/actionsrunner/UcAdfAction.groovy
@@ -250,6 +250,14 @@ abstract class UcAdfAction extends UcdObject {
 			log.info message
 		}
 	}
+	
+	/**
+	 * Log a message with log.warn.
+	 * @param message the message to log.
+	 */
+	public void logWarn(final String message) {
+		log.warn message
+	}
 
 	/**
 	 * Log a message with log.error.

--- a/src/main/groovy/org/urbancode/ucadf/core/actionsrunner/UcAdfActionsRunner.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/actionsrunner/UcAdfActionsRunner.groovy
@@ -252,6 +252,7 @@ class UcAdfActionsRunner {
 
 		UcAdfAction action
 		Exception caughtException
+		Boolean setReturnProperty = true
 		
 		// 	Try/finally used to ensure pop actions stack.	
 		try {
@@ -304,6 +305,9 @@ class UcAdfActionsRunner {
 			// Do not evaluate a when condition of the UcAdfWhen action here but rather run the action so that it can perform the elseActions if needed.
 			if (action.getWhen() && !action.getAction().equals(UcAdfWhen.getSimpleName()) && evaluateWhen(action) == false) {
 				log.debug("Skipping action [$actionName}] when [${action.getWhen()}].")
+				
+				// Don't want to set a return property value if the when condition wasn't processed.
+				setReturnProperty = false
 			} else {
 				// Show the action properties.
 				action.showProperties()
@@ -350,19 +354,21 @@ class UcAdfActionsRunner {
 			}
 	
 			// Set the return object in the actionReturn property.
-			setPropertyValue(
-				UcAdfActionPropertyEnum.ACTIONRETURN.getPropertyName(),
-				returnObject
-			)
-				
-			// Optionally, set the return object in the specified property.
-			if (action.getActionReturnPropertyName()) {
+			if (setReturnProperty) {
 				setPropertyValue(
-					action.getActionReturnPropertyName(), 
+					UcAdfActionPropertyEnum.ACTIONRETURN.getPropertyName(),
 					returnObject
 				)
-			}	
-	
+			
+				// Optionally, set the return object in the specified property.
+				if (action.getActionReturnPropertyName()) {
+					setPropertyValue(
+						action.getActionReturnPropertyName(), 
+						returnObject
+					)
+				}	
+			}
+			
 			// Action end processing.
 			action.end()
 		} catch (Exception e) {

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/applicationProcess/UcdApplicationProcessCommit.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/applicationProcess/UcdApplicationProcessCommit.groovy
@@ -1,0 +1,17 @@
+/**
+ * This class instantiates application process commit objects.
+ */
+package org.urbancode.ucadf.core.model.ucd.applicationProcess
+
+import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class UcdApplicationProcessCommit extends UcdObject {
+	Long version
+	Long commitId
+	String committer
+	Long commitTime
+	String comment
+}

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcessRequest/UcdComponentProcessRequest.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/componentProcessRequest/UcdComponentProcessRequest.groovy
@@ -15,6 +15,7 @@ class UcdComponentProcessRequest extends UcdProcessRequestTrace {
 	// Common process properties.
 	public final static String PROPNAME_REQUEST_ID = "request.id"
 	public final static String PROPNAME_PARENTREQUEST_ID = "parentRequest.id"
+	public final static String PROPNAME_COMPONENTPROCESS_NAME = "componentProcess.name"
 	
 	/** The submitted time. */
 	Long submittedTime

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/general/UcdConstants.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/general/UcdConstants.groovy
@@ -11,4 +11,7 @@ class UcdConstants {
 	// Milliseconds.
     public final static long ONE_SECOND_IN_MILLIS = 1000
     public final static long ONE_MINUTE_IN_MILLIS = 60 * ONE_SECOND_IN_MILLIS
+	
+	public final static String USERNAME_ADMIN = "admin"
+	public final static String ROLENAME_ADMINISTRATOR = "Administrator"
 }

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/system/UcdSession.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/system/UcdSession.groovy
@@ -12,6 +12,7 @@ import javax.ws.rs.core.Response
 
 import org.glassfish.jersey.client.ClientConfig
 import org.urbancode.ucadf.core.integration.jersey.JerseyManager
+import org.urbancode.ucadf.core.model.ucadf.UcAdfObject
 import org.urbancode.ucadf.core.model.ucadf.exception.UcAdfInvalidValueException
 
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -21,7 +22,7 @@ import groovy.util.logging.Slf4j
 
 @Slf4j
 @TypeChecked
-class UcdSession {
+class UcdSession extends UcAdfObject {
 	public final static String PASSWORDISAUTHTOKEN = "PasswordIsAuthToken"
 	
 	// UrbanCode version matches.

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/version/UcdVersion.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/version/UcdVersion.groovy
@@ -14,6 +14,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class UcdVersion extends UcdObject {
+	// z/OS component version properties.
+	public final static String PROPNAME_UCD_REPOSITORY_TYPE = "ucd.repository.type"
+	public final static String PROPNAME_UCD_VERSON_ISMERGED = "ucd.version.ismerged"
+	public final static String PROPNAME_UCD_VERSON_MERGEFROMVERSIONS = "ucd.version.mergefromversions"
+	
 	/** The version ID. */
 	String id
 	

--- a/src/main/groovy/org/urbancode/ucadf/core/model/ucd/version/UcdVersionLink.groovy
+++ b/src/main/groovy/org/urbancode/ucadf/core/model/ucd/version/UcdVersionLink.groovy
@@ -1,0 +1,21 @@
+/**
+ * This class instantiates a version link object.
+ */
+package org.urbancode.ucadf.core.model.ucd.version
+
+import org.urbancode.ucadf.core.model.ucd.general.UcdObject
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class UcdVersionLink extends UcdObject {
+	/** The link name. */
+	String name
+	
+	/** The link value. */
+	String value
+	
+	// Constructors.	
+	UcdVersionLink() {
+	}
+}

--- a/src/main/resources/ucadfclient
+++ b/src/main/resources/ucadfclient
@@ -33,7 +33,7 @@ then
 	
     if [ -f "$UCADFJAR" ];
     then
-		"$JAVACOMMAND" -classpath "$UCADF_CLASSPATH" -Dlog4j.configurationFile="$LOG4JPROPS" org.urbancode.ucadf.core.client.UcAdfClient $@
+		"$JAVACOMMAND" -classpath "$UCADF_CLASSPATH" -Dlog4j.configurationFile="$LOG4JPROPS" org.urbancode.ucadf.core.client.UcAdfClient "$@"
 	else
 		echo "$UCADFJAR file not found."
 		exit 1


### PR DESCRIPTION
Ability to provide UUIDs to get environment prop sheet action.
Added get environment property sheet action.
Changes to randomize concurrent update conflicts.
Added more property name constants.
Updated Jersey libraries.
Added Jersey package needed for proxy authentication.
Change to security constants.
Added user name admin constant.
Subclassed ucdSession from ucAdfObject
Fix return action property if when condition not processed.
Fix quoting problem in ucadfclient wrapper script.
Fix create resource actions to return created flag.
Fixes for create resource concurrency issues.
Fix create component resource concurrency problem.
Changes to create resource to work around unique result error.
Changes to snapshot merge versions action.
Ability for get version links to return list or map.
Throw error if single file path not found on download.
Added get application process change log action.
Logging changes.
Updated Groovy and Junit dependencies.
Added singleFilePath functionality to download version artifacts.
Added action callback functionality to merge snapshot action.
Added get version links action.
Added property merge to standard component snapshot merge.
Added ability for download version artifacts action to uncompress z/OS version package files.
Change create authentication and authorization realm actions to allow granular...